### PR TITLE
INTERLOK-3438 varsub infinite loop

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,3 +33,5 @@ jobs:
     - name: Gradle Test
       run: |
         ./gradlew -Djava.security.egd=file:/dev/./urandom -Dorg.gradle.console=plain --no-daemon -PverboseTests=true check
+    - name: codecov.io
+      uses: codecov/codecov-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
   id 'nebula.optional-base' version '5.0.3'
   id 'com.github.spotbugs' version '4.5.1'
   id 'org.owasp.dependencycheck' version '6.0.3'
+  id "io.freefair.lombok" version "5.3.0"
 }
 ext {
   interlokCoreVersion = project.hasProperty('interlokCoreVersion') ? project.getProperty('interlokCoreVersion') : '3.11-SNAPSHOT'
@@ -20,6 +21,7 @@ ext {
   repoPassword = project.hasProperty('repoPassword') ? project.getProperty('repoPassword') : 'unknown'
   defaultNexusRepo = project.hasProperty('defaultNexusRepo') ? project.getProperty('defaultNexusRepo') : 'https://repo1.maven.org/maven2/'
   offlineJavadocPackageDir = new File(project.buildDir, "offline-javadoc-packages")
+  delombokTargetDir = new File("${project.projectDir}/src/main/generated")
 
   interlokJavadocs= project.hasProperty('interlokJavadocs') ? project.getProperty('interlokJavadocs') : javadocsBaseUrl + "/interlok-core/" + interlokCoreVersion
   interlokCommonJavadocs= project.hasProperty('interlokCommonJavadocs') ? project.getProperty('interlokCommonJavadocs') : javadocsBaseUrl + "/interlok-common/" + interlokCoreVersion
@@ -27,6 +29,10 @@ ext {
   organizationName = "Adaptris Ltd"
   organizationUrl = "http://interlok.adaptris.net"
   slf4jVersion = '1.7.30'
+}
+
+ext.testResourcesDir = { ->
+  return "${project.projectDir}/src/test/resources".replaceAll("\\\\", "/")
 }
 
 if (JavaVersion.current().isJava8Compatible()) {
@@ -60,6 +66,7 @@ group   = 'com.adaptris'
 version = releaseVersion
 def versionDir = "$buildDir/version"
 def testDataDir = new File(project.buildDir, "testdata")
+generateLombokConfig.enabled = false
 
 repositories {
   mavenCentral()
@@ -181,8 +188,8 @@ task copyTestData(type: Copy) {
     filter(ReplaceTokens, tokens: [TEST_DATA_DIR: testDataDir.getCanonicalPath().replaceAll("\\\\", "/")])
 }
 
-task deleteUnitTestProperties(type: Delete) {
-    delete file('src/test/resources/unit-tests.properties')
+task deleteGeneratedFiles(type: Delete) {
+  delete file(testResourcesDir() + "/unit-tests.properties"), delombokTargetDir
 }
 
 javadoc {
@@ -209,7 +216,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
-    from sourceSets.main.allSource
+    from sourceSets.main.extensions.delombokTask
 }
 
 artifacts {
@@ -282,5 +289,5 @@ spotbugsTest.enabled = false
 
 check.dependsOn jacocoTestReport
 processTestResources.dependsOn copyUnitTestProperties, copyTestData
-clean.dependsOn deleteUnitTestProperties
+clean.dependsOn deleteGeneratedFiles
 javadoc.dependsOn offlinePackageList

--- a/src/main/java/com/adaptris/core/varsub/Constants.java
+++ b/src/main/java/com/adaptris/core/varsub/Constants.java
@@ -1,18 +1,22 @@
 package com.adaptris.core.varsub;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 /**
  * Constants used by various pre-processors.
- * 
+ *
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Constants {
   /**
    * The default variable prefix, {@value #DEFAULT_VARIABLE_PREFIX}
-   * 
+   *
    */
   public static final String DEFAULT_VARIABLE_PREFIX = "${";
   /**
    * The default variable postfix, {@value #DEFAULT_VARIABLE_POSTFIX}
-   * 
+   *
    */
   public static final String DEFAULT_VARIABLE_POSTFIX = "}";
 
@@ -23,19 +27,19 @@ public class Constants {
 
   /**
    * The key in configuration controlling the prefix: {@value #VARSUB_PREFIX_KEY}, defaults to {@value #DEFAULT_VARIABLE_PREFIX}
-   * 
+   *
    */
   public static final String VARSUB_PREFIX_KEY = "variable-substitution.varprefix";
   /**
    * The key in configuration controlling the prefix, {@value #VARSUB_POSTFIX_KEY}, defaults to {@value #DEFAULT_VARIABLE_POSTFIX}
-   * 
+   *
    */
   public static final String VARSUB_POSTFIX_KEY = "variable-substitution.varpostfix";
 
   /**
    * The key in configuration defining the properties file where variables are defined:
    * {@value #VARSUB_PROPERTIES_URL_KEY}.
-   * 
+   *
    */
   public static final String VARSUB_PROPERTIES_URL_KEY = "variable-substitution.properties.url";
 
@@ -55,12 +59,12 @@ public class Constants {
 
   /**
    * The key in configuration controlling the prefix: {@value #SYSPROP_PREFIX_KEY}
-   * 
+   *
    */
   public static final String SYSPROP_PREFIX_KEY = "system-properties.varprefix";
   /**
    * The key in configuration controlling the prefix: {@value #SYSPROP_POSTFIX_KEY}
-   * 
+   *
    */
   public static final String SYSPROP_POSTFIX_KEY = "system-properties.varpostfix";
 
@@ -71,18 +75,18 @@ public class Constants {
 
   /**
    * The key in configuration controlling the prefix: {@value #ENVVAR_PREFIX_KEY}
-   * 
+   *
    */
   public static final String ENVVAR_PREFIX_KEY = "environment-variables.varprefix";
   /**
    * The key in configuration controlling the prefix: {@value #ENVVAR_POSTFIX_KEY}
-   * 
+   *
    */
   public static final String ENVVAR_POSTFIX_KEY = "environment-variables.varpostfix";
 
   /**
    * The key in configuration controlling the substitution method: {@value #ENVVAR_IMPL_KEY}, defaults to {@code SIMPLE}
-   * 
+   *
    */
   public static final String ENVVAR_IMPL_KEY = "environment-variables.impl";
 }

--- a/src/main/java/com/adaptris/core/varsub/VariableExpander.java
+++ b/src/main/java/com/adaptris/core/varsub/VariableExpander.java
@@ -62,7 +62,6 @@ public class VariableExpander {
       Properties environment = PropertyFileLoader.getEnvironment();
       for (String key : resolved.stringPropertyNames()) {
         String value = resolved.getProperty(key);
-        value = handleExpansion(key, value, resolved);
         log.trace("Initial key [{}], value[{}]", key, value);
         // Loop through and sort out all the defined variables first.
         value = handleExpansion(key, value, resolved);

--- a/src/main/java/com/adaptris/core/varsub/VariableExpander.java
+++ b/src/main/java/com/adaptris/core/varsub/VariableExpander.java
@@ -3,12 +3,11 @@ package com.adaptris.core.varsub;
 import java.util.LinkedHashSet;
 import java.util.Properties;
 import java.util.Set;
-
 import org.apache.commons.lang3.StringUtils;
-
 import com.adaptris.core.CoreException;
 import com.adaptris.core.management.properties.PropertyResolver;
 import com.adaptris.core.util.ExceptionHelper;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Creates a resolved set of substitutions for use by {@link Processor}.
@@ -40,10 +39,11 @@ adapter.d96a.dir.out=d96a-out
  * </pre>
  * </code>
  * <p>
- * 
+ *
  * @author lchan
- * 
+ *
  */
+@Slf4j
 public class VariableExpander {
 
   private String varPrefix;
@@ -55,45 +55,51 @@ public class VariableExpander {
   }
 
   public Properties resolve(Properties input) throws CoreException {
-    Properties resolved = resolveCustom(input);
     Properties result = new Properties();
-    Properties sysProps = System.getProperties();
-    Properties environment = PropertyFileLoader.getEnvironment();
-
-    Set<String> variables = createVariableNames(resolved);
-    Set<String> sysPropVariables = createVariableNames(sysProps);
-    Set<String> environmentVariables = createVariableNames(environment);
-
-    for (String key : resolved.stringPropertyNames()) {
-      String value = resolved.getProperty(key);
-      // Loop through and sort out all the defined variables first.
-      while (containsVariable(value, variables)) {
-        value = expand(value, resolved);
+    try {
+      Properties resolved = resolveCustom(input);
+      Properties sysProps = System.getProperties();
+      Properties environment = PropertyFileLoader.getEnvironment();
+      for (String key : resolved.stringPropertyNames()) {
+        String value = resolved.getProperty(key);
+        value = handleExpansion(key, value, resolved);
+        log.trace("Initial key [{}], value[{}]", key, value);
+        // Loop through and sort out all the defined variables first.
+        value = handleExpansion(key, value, resolved);
+        // Now loop through and expand any system properties.
+        value = handleExpansion(key, value, sysProps);
+        // Now loop through and expand any environment variables.
+        value = handleExpansion(key, value, environment);
+        result.setProperty(key, value);
       }
-      // Now loop through and expand any system properties.
-      while (containsVariable(value, sysPropVariables)) {
-        value = expand(value, sysProps);
-      }
-
-      // Now loop through and expand any environment variables.
-      while (containsVariable(value, environmentVariables)) {
-        value = expand(value, environment);
-      }
-      result.setProperty(key, value);
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapCoreException(e);
     }
     return result;
   }
 
-  private Properties resolveCustom(Properties input) throws CoreException {
-    Properties result = new Properties();
-    try {
-      PropertyResolver resolver = PropertyResolver.getDefaultInstance();
-      for (String key : input.stringPropertyNames()) {
-        String value = StringUtils.trimToEmpty(input.getProperty(key));
-        result.setProperty(key, resolver.resolve(value));
+  private String handleExpansion(String key, String initialValue, Properties knownVariables)
+      throws Exception {
+    String value = initialValue;
+    Set<String> variables = createVariableNames(knownVariables);
+    while (containsVariable(value, variables)) {
+      String expanded = expand(value, knownVariables);
+      if (value.equalsIgnoreCase(expanded)) {
+        String s = String.format("Expansion Failure :[%s], self-referential variables?", key);
+        log.error(s);
+        throw new Exception(s);
       }
-    } catch (Exception exc) {
-      throw ExceptionHelper.wrapCoreException(exc);
+      value = expanded;
+    }
+    return value;
+  }
+
+  private Properties resolveCustom(Properties input) throws Exception {
+    Properties result = new Properties();
+    PropertyResolver resolver = PropertyResolver.getDefaultInstance();
+    for (String key : input.stringPropertyNames()) {
+      String value = StringUtils.trimToEmpty(input.getProperty(key));
+      result.setProperty(key, resolver.resolve(value));
     }
     return result;
   }

--- a/src/main/java/com/adaptris/core/varsub/VariableSubstitutionType.java
+++ b/src/main/java/com/adaptris/core/varsub/VariableSubstitutionType.java
@@ -1,15 +1,18 @@
 package com.adaptris.core.varsub;
 
+import com.adaptris.annotation.Removal;
 
 public enum VariableSubstitutionType {
-  
+
   SIMPLE() {
     @Override
     VariableSubstitutable create() {
       return new SimpleStringSubstitution();
     }
   },
-  @Deprecated simple() {
+  @Deprecated
+  @Removal(version = "4.0.0")
+  simple() {
     @Override
     VariableSubstitutable create() {
       return new SimpleStringSubstitution();
@@ -21,7 +24,9 @@ public enum VariableSubstitutionType {
       return new SimpleStringSubstitution(true, false);
     }
   },
-  @Deprecated simpleWithLogging() {
+  @Deprecated
+  @Removal(version = "4.0.0")
+  simpleWithLogging() {
     @Override
     VariableSubstitutable create() {
       return new SimpleStringSubstitution(true, false);
@@ -33,7 +38,9 @@ public enum VariableSubstitutionType {
       return new SimpleStringSubstitution(false, true);
     }
   },
-  @Deprecated strict() {
+  @Deprecated
+  @Removal(version = "4.0.0")
+  strict() {
     @Override
     VariableSubstitutable create() {
       return new SimpleStringSubstitution(false, true);
@@ -45,13 +52,15 @@ public enum VariableSubstitutionType {
       return new SimpleStringSubstitution(true, true);
     }
   },
-  @Deprecated strictWithLogging() {
+  @Deprecated
+  @Removal(version = "4.0.0")
+  strictWithLogging() {
     @Override
     VariableSubstitutable create() {
       return new SimpleStringSubstitution(true, true);
     }
   };
-  
+
   abstract VariableSubstitutable create();
-  
+
 }

--- a/src/main/resources/META-INF/com/adaptris/core/preprocessor/varsub
+++ b/src/main/resources/META-INF/com/adaptris/core/preprocessor/varsub
@@ -1,0 +1,1 @@
+class=com.adaptris.core.varsub.VariableSubstitutionPreProcessor


### PR DESCRIPTION
## Motivation

Contents of bootstrap.properties 
```
preProcessors=variableSubstitution
variable-substitution.properties.url.0=file://localhost/./config/variables.properties
```
Contents of variables.properties (note that MY_VAR doesn't even have to be used in your config)

```
adapter.id=MyInterlokInstance
my.variable=${adapter.id}
MY_VAR=${MY_VAR}
```

Causes any attempt to start the adapter to effectively 'hang' hitting 100% CPU.

## Modification

- VariableExpander now throws an exception if it did no work (i.e. when attempting to expand; it didn't actually do anything) which means we fail fast.
- Add tests for self-referential variables 'VAR=${VAR}'
- added 'varsub' as an undocumented valid alternative for pre-processors

## Result

The above variables property file will now log an error and fail.

## Testing

With this PR you should get (with the above config)

```
ERROR [main] [c.a.c.v.VariableExpander.handleExpansion()] Expansion Failure :[MY_VAR], self-referential variables?
```

If you aren't using this PR then you can stick your head next to your machine, and dry your hair.
