### PR TITLE
INTERLOK-3559 Fixed deprecated classes, also fixed a few warnings.

### DIFF
--- a/src/main/java/com/adaptris/core/varsub/Processor.java
+++ b/src/main/java/com/adaptris/core/varsub/Processor.java
@@ -11,6 +11,7 @@ import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.Properties;
 
 import org.apache.commons.io.IOUtils;
@@ -39,7 +40,7 @@ class Processor {
   String process(URL urlToXml, Properties variables) throws CoreException {
     String result = null;
     try (InputStream inputStream = urlToXml.openConnection().getInputStream()) {
-      String xml = IOUtils.toString(inputStream);
+      String xml = IOUtils.toString(inputStream, Charset.defaultCharset());
       result = this.process(xml, variables);
     }
     catch (IOException ex) {

--- a/src/main/java/com/adaptris/core/varsub/SystemPropertiesPreProcessor.java
+++ b/src/main/java/com/adaptris/core/varsub/SystemPropertiesPreProcessor.java
@@ -10,9 +10,6 @@ import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 
 import java.util.Properties;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.adaptris.core.CoreException;
 import com.adaptris.core.management.BootstrapProperties;
 import com.adaptris.util.KeyValuePairSet;
@@ -70,8 +67,6 @@ import com.adaptris.util.KeyValuePairSet;
  * @since 3.0.1
  */
 public class SystemPropertiesPreProcessor extends VariablePreProcessorImpl {
-
-  private transient Logger log = LoggerFactory.getLogger(this.getClass());
 
   public SystemPropertiesPreProcessor(BootstrapProperties bootstrapProperties) {
     super(bootstrapProperties);

--- a/src/main/java/com/adaptris/core/varsub/VariablePreProcessorImpl.java
+++ b/src/main/java/com/adaptris/core/varsub/VariablePreProcessorImpl.java
@@ -3,6 +3,7 @@ package com.adaptris.core.varsub;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.Charset;
 
 import org.apache.commons.io.IOUtils;
 
@@ -39,7 +40,7 @@ public abstract class VariablePreProcessorImpl extends ConfigPreProcessorImpl {
   public String process(URL urlToXml) throws CoreException {
     String result = null;
     try (InputStream inputStream = urlToXml.openConnection().getInputStream()) {
-      result = process(IOUtils.toString(inputStream));
+      result = process(IOUtils.toString(inputStream, Charset.defaultCharset()));
     }
     catch (IOException ex) {
       throw ExceptionHelper.wrapCoreException(ex);

--- a/src/main/java/com/adaptris/core/varsub/XStreamMarshaller.java
+++ b/src/main/java/com/adaptris/core/varsub/XStreamMarshaller.java
@@ -6,6 +6,7 @@ import static com.adaptris.core.varsub.Constants.VARSUB_IMPL_KEY;
 import static com.adaptris.core.varsub.Constants.VARSUB_POSTFIX_KEY;
 import static com.adaptris.core.varsub.Constants.VARSUB_PREFIX_KEY;
 import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -13,14 +14,16 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.net.InetAddress;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.BooleanUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
@@ -56,7 +59,6 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 @XStreamAlias("xstream-varsub-marshaller")
 public class XStreamMarshaller extends com.adaptris.core.XStreamMarshaller {
 
-  private transient Logger log = LoggerFactory.getLogger(this.getClass());
   private transient PropertyFileLoader loader = new PropertyFileLoader();
 
   @XStreamImplicit(itemFieldName = "variable-properties-url")
@@ -148,7 +150,7 @@ public class XStreamMarshaller extends com.adaptris.core.XStreamMarshaller {
     Args.notNull(in, "inputstream");
     Object result = null;
     try (InputStream autoClose = in) {
-      String xml = IOUtils.toString(autoClose);
+      String xml = IOUtils.toString(autoClose, Charset.defaultCharset());
       result = unmarshal(xml);
     }
     catch (IOException e) {

--- a/src/test/java/com/adaptris/core/varsub/EnvironmentVariablesPreProcessorTest.java
+++ b/src/test/java/com/adaptris/core/varsub/EnvironmentVariablesPreProcessorTest.java
@@ -2,12 +2,13 @@ package com.adaptris.core.varsub;
 
 import static org.junit.Assert.assertEquals;
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.Properties;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 import com.adaptris.core.Adapter;
-import com.adaptris.core.BaseCase;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.stubs.JunitBootstrapProperties;
 import com.adaptris.util.KeyValuePairSet;
@@ -20,10 +21,6 @@ public class EnvironmentVariablesPreProcessorTest extends BaseCase {
   private Properties bootstrapProperties;
   private File adapterXmlFile;
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
   @Before
   public void setUp() throws Exception {
     adapterXmlFile = new File(PROPERTIES.getProperty(KEY_ENV_ADAPTER_XML));
@@ -49,7 +46,7 @@ public class EnvironmentVariablesPreProcessorTest extends BaseCase {
   @Test
   public void testEnvironmentVariableReplacement_String() throws Exception {
 
-    String xml = preProcessor.process(IOUtils.toString(adapterXmlFile.toURI().toURL()));
+    String xml = preProcessor.process(IOUtils.toString(adapterXmlFile.toURI().toURL(), Charset.defaultCharset()));
     Adapter adapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(xml);
 
     doStandardAssertions(adapter);

--- a/src/test/java/com/adaptris/core/varsub/PropertyFileLoaderTest.java
+++ b/src/test/java/com/adaptris/core/varsub/PropertyFileLoaderTest.java
@@ -6,18 +6,13 @@ import static org.junit.Assert.fail;
 import java.io.FileNotFoundException;
 import java.util.Properties;
 import org.junit.Test;
-import com.adaptris.core.BaseCase;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
 import com.adaptris.util.URLString;
 
 public class PropertyFileLoaderTest extends BaseCase {
 
   public static final String SAMPLE_SUBSTITUTION_PROPERTIES = "varsub.variables.properties";
   public static final String SAMPLE_MISSING_SUBSTITUTION_PROPERTIES = "varsub.missing.variables.properties";
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 
   @Test
   public void testLoad() throws Exception {

--- a/src/test/java/com/adaptris/core/varsub/SimpleStringSubstitutionTest.java
+++ b/src/test/java/com/adaptris/core/varsub/SimpleStringSubstitutionTest.java
@@ -97,7 +97,7 @@ public class SimpleStringSubstitutionTest extends TestCase {
     props.put("fox", "fox");
     props.put("dog", "dog");
     try {
-      String substitution = VariableSubstitutionType.SIMPLE.create().doSubstitution(testInput, props, "${", "}");
+      VariableSubstitutionType.SIMPLE.create().doSubstitution(testInput, props, "${", "}");
     } catch (CoreException e) {
       assertTrue(e.getMessage().contains("${over} is undefined"));
     }
@@ -108,7 +108,7 @@ public class SimpleStringSubstitutionTest extends TestCase {
     props.put("fox", "fox");
     props.put("dog", "dog");
     try {
-      String substitution = VariableSubstitutionType.SIMPLE_WITH_LOGGING.create().doSubstitution(testInput, props, "${", "}");
+      VariableSubstitutionType.SIMPLE_WITH_LOGGING.create().doSubstitution(testInput, props, "${", "}");
     } catch (CoreException e) {
       assertTrue(e.getMessage().contains("${over} is undefined"));
     }

--- a/src/test/java/com/adaptris/core/varsub/SystemPropertiesPreProcessorTest.java
+++ b/src/test/java/com/adaptris/core/varsub/SystemPropertiesPreProcessorTest.java
@@ -2,12 +2,13 @@ package com.adaptris.core.varsub;
 
 import static org.junit.Assert.assertEquals;
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.Properties;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 import com.adaptris.core.Adapter;
-import com.adaptris.core.BaseCase;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.stubs.JunitBootstrapProperties;
 import com.adaptris.util.KeyValuePairSet;
@@ -19,11 +20,6 @@ public class SystemPropertiesPreProcessorTest extends BaseCase {
 
   private Properties bootstrapProperties;
   private File adapterXmlFile;
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
   
   @Before
   public void setUp() throws Exception {
@@ -48,7 +44,7 @@ public class SystemPropertiesPreProcessorTest extends BaseCase {
   @Test
   public void testSystemPropertyReplacement_String() throws Exception {
 
-    String xml = preProcessor.process(IOUtils.toString(adapterXmlFile.toURI().toURL()));
+    String xml = preProcessor.process(IOUtils.toString(adapterXmlFile.toURI().toURL(), Charset.defaultCharset()));
     Adapter adapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(xml);
 
     doStandardAssertions(adapter);

--- a/src/test/java/com/adaptris/core/varsub/VariableSubstitutionPreProcessorTest.java
+++ b/src/test/java/com/adaptris/core/varsub/VariableSubstitutionPreProcessorTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.Properties;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -14,7 +15,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import com.adaptris.core.Adapter;
-import com.adaptris.core.BaseCase;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.stubs.JunitBootstrapProperties;
@@ -33,15 +34,10 @@ public class VariableSubstitutionPreProcessorTest extends BaseCase {
 
   private Properties sampleBootstrapProperties;
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-
   @Before
   public void setUp() throws Exception {
 
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
 
     variablesAdapterFile = new File(PROPERTIES.getProperty(PROPS_VARIABLES_ADAPTER));
 
@@ -73,7 +69,7 @@ public class VariableSubstitutionPreProcessorTest extends BaseCase {
     Properties variableSubstitutions = createProperties();
     when(propertyFileLoader.load(anyString(), anyBoolean())).thenReturn(variableSubstitutions);
 
-    String xml = preProcessor.process(IOUtils.toString(variablesAdapterFile.toURI().toURL()));
+    String xml = preProcessor.process(IOUtils.toString(variablesAdapterFile.toURI().toURL(), Charset.defaultCharset()));
     Adapter adapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(xml);
 
     doStandardAssertions(adapter);
@@ -203,7 +199,7 @@ public class VariableSubstitutionPreProcessorTest extends BaseCase {
 
     String adapterXml = preProcessor.process(variablesAdapterFile.toURI().toURL());
 
-    assertEquals(FileUtils.readFileToString(variablesAdapterFile), adapterXml);
+    assertEquals(FileUtils.readFileToString(variablesAdapterFile, Charset.defaultCharset()), adapterXml);
   }
 
   @Test
@@ -265,7 +261,7 @@ public class VariableSubstitutionPreProcessorTest extends BaseCase {
     Properties variableSubstitutions = createProperties();
     variableSubstitutions.setProperty("SELF_REFERENTIAL", "${SELF_REFERENTIAL}");
     when(propertyFileLoader.load(anyString(), anyBoolean())).thenReturn(variableSubstitutions);
-    String xml = preProcessor.process(variablesAdapterFile.toURI().toURL());
+    preProcessor.process(variablesAdapterFile.toURI().toURL());
   }
 
   private void doStandardAssertions(Adapter adapter) {

--- a/src/test/java/com/adaptris/core/varsub/VariableSubstitutionPreProcessorTest.java
+++ b/src/test/java/com/adaptris/core/varsub/VariableSubstitutionPreProcessorTest.java
@@ -10,6 +10,7 @@ import java.nio.charset.Charset;
 import java.util.Properties;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -34,10 +35,11 @@ public class VariableSubstitutionPreProcessorTest extends BaseCase {
 
   private Properties sampleBootstrapProperties;
 
+  private AutoCloseable mocks;
+  
   @Before
   public void setUp() throws Exception {
-
-    MockitoAnnotations.openMocks(this);
+    mocks = MockitoAnnotations.openMocks(this);
 
     variablesAdapterFile = new File(PROPERTIES.getProperty(PROPS_VARIABLES_ADAPTER));
 
@@ -49,6 +51,11 @@ public class VariableSubstitutionPreProcessorTest extends BaseCase {
 
     preProcessor = new VariableSubstitutionPreProcessor(new JunitBootstrapProperties(sampleBootstrapProperties));
     preProcessor.setPropertyFileLoader(propertyFileLoader);
+  }
+  
+  @After
+  public void tearDown() throws Exception {
+    mocks.close();
   }
 
   @Test

--- a/src/test/java/com/adaptris/core/varsub/XStreamMarshallerTest.java
+++ b/src/test/java/com/adaptris/core/varsub/XStreamMarshallerTest.java
@@ -8,11 +8,13 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.nio.charset.Charset;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 import com.adaptris.core.Adapter;
-import com.adaptris.core.BaseCase;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
 import com.adaptris.core.CoreException;
 import com.adaptris.util.GuidGenerator;
 import com.adaptris.util.URLString;
@@ -23,11 +25,6 @@ public class XStreamMarshallerTest extends BaseCase {
   private static final String SAMPLE_SUBSTITUTION_PROPERTIES = "varsub.variables.properties";
 
   private File variablesAdapterFile;
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 
   @Before
   public void setUp() throws Exception {
@@ -43,7 +40,7 @@ public class XStreamMarshallerTest extends BaseCase {
   @Test
   public void testUnmarshal_String() throws Exception {
     Adapter adapter = (Adapter) createMarshaller().withUseHostname(true)
-        .unmarshal(IOUtils.toString(variablesAdapterFile.toURI().toURL()));
+        .unmarshal(IOUtils.toString(variablesAdapterFile.toURI().toURL(), Charset.defaultCharset()));
     doStandardAssertions(adapter);
 
   }
@@ -165,7 +162,7 @@ public class XStreamMarshallerTest extends BaseCase {
 
   @Test
   public void testUnmarshal_NoSubstitution() throws Exception {
-    String xml = IOUtils.toString(variablesAdapterFile.toURI().toURL());
+    String xml = IOUtils.toString(variablesAdapterFile.toURI().toURL(), Charset.defaultCharset());
     Adapter adapter = (Adapter) new XStreamMarshaller().unmarshal(xml);
     assertEquals("${adapter.id}", adapter.getUniqueId());
   }
@@ -175,7 +172,7 @@ public class XStreamMarshallerTest extends BaseCase {
     XStreamMarshaller marshaller = createMarshaller();
     marshaller.setVariablePrefix(Constants.DEFAULT_VARIABLE_PREFIX);
     marshaller.setVariablePostfix(Constants.DEFAULT_VARIABLE_POSTFIX);
-    Adapter adapter = (Adapter) marshaller.unmarshal(IOUtils.toString(variablesAdapterFile.toURI().toURL()));
+    Adapter adapter = (Adapter) marshaller.unmarshal(IOUtils.toString(variablesAdapterFile.toURI().toURL(), Charset.defaultCharset()));
     doStandardAssertions(adapter);
 
   }
@@ -184,7 +181,7 @@ public class XStreamMarshallerTest extends BaseCase {
   public void testUnmarshal_WithLogging() throws Exception {
     XStreamMarshaller marshaller = createMarshaller();
     marshaller.setSubstitutionType(VariableSubstitutionType.SIMPLE_WITH_LOGGING);
-    Adapter adapter = (Adapter) marshaller.unmarshal(IOUtils.toString(variablesAdapterFile.toURI().toURL()));
+    Adapter adapter = (Adapter) marshaller.unmarshal(IOUtils.toString(variablesAdapterFile.toURI().toURL(), Charset.defaultCharset()));
     doStandardAssertions(adapter);
 
   }


### PR DESCRIPTION
## Motivation

We're removing all of the deprecated for v4 class references.

## Modification

BaseCase now uses the scaffolding package version.  Also fixed a few warnings like unused loggers and variables.

## Result

Project is now clean of warnings.

