### PR TITLE
INTERLOK-4358 Add a new service that can do variable substitution

### DIFF
--- a/src/main/java/com/adaptris/core/varsub/VariableSubstitutionService.java
+++ b/src/main/java/com/adaptris/core/varsub/VariableSubstitutionService.java
@@ -1,0 +1,157 @@
+package com.adaptris.core.varsub;
+
+import static com.adaptris.core.varsub.Constants.DEFAULT_VARIABLE_POSTFIX;
+import static com.adaptris.core.varsub.Constants.DEFAULT_VARIABLE_PREFIX;
+import static com.adaptris.core.varsub.Constants.VARSUB_IMPL_KEY;
+import static com.adaptris.core.varsub.Constants.VARSUB_POSTFIX_KEY;
+import static com.adaptris.core.varsub.Constants.VARSUB_PREFIX_KEY;
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+
+import java.io.StringReader;
+import java.util.Properties;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.Args;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.interlok.config.DataInputParameter;
+import com.adaptris.interlok.config.DataOutputParameter;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * A service that does variable substitution to a string input
+ */
+@XStreamAlias("variable-substitution-service")
+public class VariableSubstitutionService extends com.adaptris.core.ServiceImp {
+
+  /**
+   * The input to process.
+   */
+  @Valid
+  @NotNull
+  @Getter
+  @Setter
+  private DataInputParameter<String> input;
+
+  /**
+   * Where to output the processed input
+   */
+  @Valid
+  @NotNull
+  @Getter
+  @Setter
+  private DataOutputParameter<String> output;
+
+  /**
+   * The variable properties.
+   */
+  @Valid
+  @NotNull
+  @Getter
+  @Setter
+  private DataInputParameter<String> variables;
+
+  /**
+   * Set the Substitution Type.
+   *
+   * If not specified then {@link VariableSubstitutionType#SIMPLE}.
+   */
+  @AdvancedConfig
+  @Getter
+  @Setter
+  private VariableSubstitutionType substitutionType;
+
+  /**
+   * Set the variable prefix.
+   *
+   * Defaults to {@value com.adaptris.core.varsub.Constants#DEFAULT_VARIABLE_PREFIX}
+   */
+  @InputFieldDefault(Constants.DEFAULT_VARIABLE_PREFIX)
+  @AdvancedConfig
+  @Getter
+  @Setter
+  private String variablePrefix;
+
+  /**
+   * Set the variable postfix.
+   *
+   * Defaults to {@value com.adaptris.core.varsub.Constants#DEFAULT_VARIABLE_POSTFIX}
+   */
+  @InputFieldDefault(Constants.DEFAULT_VARIABLE_POSTFIX)
+  @AdvancedConfig
+  @Getter
+  @Setter
+  private String variablePostfix;
+
+  public VariableSubstitutionService() throws CoreException {
+  }
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    try {
+      String processed = process(getInput().extract(msg), loadSubstitutions(msg));
+      getOutput().insert(processed, msg);
+    } catch (Exception expt) {
+      throw ExceptionHelper.wrapServiceException(expt);
+    }
+  }
+
+  @Override
+  public void prepare() throws CoreException {
+  }
+
+  @Override
+  protected void initService() throws CoreException {
+  }
+
+  @Override
+  protected void closeService() {
+  }
+
+  public String process(String inputToProcess, Properties properties) throws CoreException {
+    Args.notNull(inputToProcess, "input");
+    String xml = new Processor(configAsProperties()).process(inputToProcess, properties);
+    return xml;
+  }
+
+  private Properties loadSubstitutions(AdaptrisMessage msg) throws CoreException {
+    Properties result = new Properties();
+    try {
+      String variablesStr = getVariables().extract(msg);
+      result.load(new StringReader(variablesStr));
+    } catch (Exception expts) {
+      throw ExceptionHelper.wrapCoreException(expts);
+    }
+    return result;
+  }
+
+  private Properties configAsProperties() {
+    Properties config = new Properties();
+    config.setProperty(VARSUB_PREFIX_KEY, variablePrefix());
+    config.setProperty(VARSUB_POSTFIX_KEY, variableSuffix());
+    config.setProperty(VARSUB_IMPL_KEY, substitutionImpl().name());
+    return config;
+  }
+
+  String variablePrefix() {
+    return defaultIfBlank(getVariablePrefix(), DEFAULT_VARIABLE_PREFIX);
+  }
+
+  String variableSuffix() {
+    return defaultIfBlank(getVariablePostfix(), DEFAULT_VARIABLE_POSTFIX);
+  }
+
+  VariableSubstitutionType substitutionImpl() {
+    return getSubstitutionType() != null ? getSubstitutionType() : VariableSubstitutionType.SIMPLE;
+  }
+
+}

--- a/src/main/java/com/adaptris/core/varsub/VariableSubstitutionService.java
+++ b/src/main/java/com/adaptris/core/varsub/VariableSubstitutionService.java
@@ -13,7 +13,10 @@ import java.util.Properties;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
@@ -30,6 +33,9 @@ import lombok.Setter;
 /**
  * A service that does variable substitution to a string input
  */
+@AdapterComponent
+@ComponentProfile(summary = "Variable substitution on a message payload or metadata", tag = "service,varsub")
+@DisplayOrder(order = { "input", "output", "variables", "variablePrefix", "variablePostfix" })
 @XStreamAlias("variable-substitution-service")
 public class VariableSubstitutionService extends com.adaptris.core.ServiceImp {
 

--- a/src/test/java/com/adaptris/core/varsub/VariableSubstitutionServiceTest.java
+++ b/src/test/java/com/adaptris/core/varsub/VariableSubstitutionServiceTest.java
@@ -1,0 +1,58 @@
+package com.adaptris.core.varsub;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.common.ConstantDataInputParameter;
+import com.adaptris.core.common.StringPayloadDataInputParameter;
+import com.adaptris.core.common.StringPayloadDataOutputParameter;
+import com.adaptris.core.util.LifecycleHelper;
+
+public class VariableSubstitutionServiceTest {
+
+  @Test
+  public void testDoService() throws IOException, CoreException, ParserConfigurationException, SAXException, URISyntaxException {
+    VariableSubstitutionService service = new VariableSubstitutionService();
+    service.setInput(new StringPayloadDataInputParameter());
+    service.setOutput(new StringPayloadDataOutputParameter());
+    service.setVariables(new ConstantDataInputParameter("var=variable"));
+
+    String input = "some text with some ${var} key to replace";
+    AdaptrisMessage msg = DefaultMessageFactory.getDefaultInstance().newMessage(input);
+
+    LifecycleHelper.initAndStart(service);
+    service.doService(msg);
+    LifecycleHelper.close(service);
+
+    assertEquals("some text with some variable key to replace", msg.getContent());
+  }
+
+  @Test
+  public void testDoServiceTwiseSameKey()
+      throws IOException, CoreException, ParserConfigurationException, SAXException, URISyntaxException {
+    VariableSubstitutionService service = new VariableSubstitutionService();
+    service.setInput(new StringPayloadDataInputParameter());
+    service.setOutput(new StringPayloadDataOutputParameter());
+    service.setVariables(new ConstantDataInputParameter("var=variable\nvar=var"));
+
+    String input = "some text with some ${var} key to replace";
+    AdaptrisMessage msg = DefaultMessageFactory.getDefaultInstance().newMessage(input);
+
+    LifecycleHelper.initAndStart(service);
+    service.doService(msg);
+    LifecycleHelper.close(service);
+
+    assertEquals("some text with some var key to replace", msg.getContent());
+  }
+
+}


### PR DESCRIPTION
…



## Motivation

We need a service that can do var sub on a part of a message
This is mainly for the upgrade tool but can find usage somewhere else hence we add it to this optional component.

## Modification

Add a new service that can do variable substitution on the message payload or metadata

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.

## Result

There is a new service that can do variable substitution

## Testing

Build this optional component and add it to your classpath.

Configure the service like this:

```xml
<variable-substitution-service>
  <unique-id>varsub</unique-id>
  <input class="string-payload-data-input-parameter"/>
  <output class="string-payload-data-output-parameter"/>
  <variables class="metadata-data-input-parameter">
    <metadata-key>all-dtd-properties</metadata-key>
  </variables>
  <substitution-type>SIMPLE</substitution-type>
</variable-substitution-service>
```

Have a payload with varsub token `${token}` and a metadata with properties `key=val` and run the service to see it doing the substitution.