### PR TITLE
INTERLOK-4556: Implement log masking

### DIFF
--- a/src/main/java/com/adaptris/core/varsub/Constants.java
+++ b/src/main/java/com/adaptris/core/varsub/Constants.java
@@ -44,6 +44,11 @@ public class Constants {
   public static final String VARSUB_PROPERTIES_URL_KEY = "variable-substitution.properties.url";
 
   /**
+   * The key in configuration defining a comma separated list of variables that should be masked
+   */
+  public static final String VARSUB_LOG_MASKED_VARIABLES_KEY = "variable-substitution.properties.maskedVariables";
+
+  /**
    * The key in configuration defining the properties file allowing formatting of the URL: {@value #VARSUB_PROPERTIES_USE_HOSTNAME}.
    * <p>
    * The default is false, but if set to true, then each URL defined by {@value #VARSUB_PROPERTIES_URL_KEY} will be formatted using

--- a/src/main/java/com/adaptris/core/varsub/EnvironmentVariablesPreProcessor.java
+++ b/src/main/java/com/adaptris/core/varsub/EnvironmentVariablesPreProcessor.java
@@ -83,8 +83,7 @@ public class EnvironmentVariablesPreProcessor extends VariablePreProcessorImpl {
     String varSubImpl = defaultIfBlank(cfg.getProperty(ENVVAR_IMPL_KEY), DEFAULT_VAR_SUB_IMPL);
     String variablePrefix = defaultIfBlank(cfg.getProperty(ENVVAR_PREFIX_KEY), DEFAULT_VARIABLE_PREFIX);
     String variablePostfix = defaultIfBlank(cfg.getProperty(ENVVAR_POSTFIX_KEY), DEFAULT_VARIABLE_POSTFIX);
-    VariableSubstitutionType impl = VariableSubstitutionType.valueOf(varSubImpl);
-    return impl.create().doSubstitution(xml, PropertyFileLoader.getEnvironment(), variablePrefix, variablePostfix);
+    return build(varSubImpl).doSubstitution(xml, PropertyFileLoader.getEnvironment(), variablePrefix, variablePostfix);
   }
 
 }

--- a/src/main/java/com/adaptris/core/varsub/LogMasking.java
+++ b/src/main/java/com/adaptris/core/varsub/LogMasking.java
@@ -1,0 +1,35 @@
+package com.adaptris.core.varsub;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+public class LogMasking {
+
+    public static final String LOG_MASKING_CONFIG_KEY = Constants.VARSUB_LOG_MASKED_VARIABLES_KEY;
+    public static final String DEFAULT_LOG_MASK = "***";
+    public static final String DEFAULT_LOG_MASKING_CONFIG_DELIMITER = ",";
+
+    public static List<String> getLogMaskingConfigKeys(Properties cfg) {
+        return getLogMaskingConfigKeys(cfg, DEFAULT_LOG_MASKING_CONFIG_DELIMITER);
+
+    }
+    public static List<String> getLogMaskingConfigKeys(Properties cfg, String delimiter) {
+        String untokenizedKeys = cfg.getProperty(LOG_MASKING_CONFIG_KEY);
+        if (untokenizedKeys != null) {
+            return Arrays.asList(untokenizedKeys.split(delimiter));
+        }
+        return Collections.emptyList();
+    }
+
+    public static String getLogMaskedValue(List<String> logMaskedKeys, String key, String value) {
+        return getLogMaskedValue(logMaskedKeys, key, value,  DEFAULT_LOG_MASK);
+    }
+
+    public static String getLogMaskedValue(List<String> logMaskedKeys, String key, String value, String mask) {
+        if (logMaskedKeys != null && logMaskedKeys.contains(key)) {
+            return mask;
+        } else return value;
+    }
+}

--- a/src/main/java/com/adaptris/core/varsub/Processor.java
+++ b/src/main/java/com/adaptris/core/varsub/Processor.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.util.List;
 import java.util.Properties;
 
 import org.apache.commons.io.IOUtils;
@@ -31,10 +32,21 @@ class Processor {
     String varSubImpl = defaultIfBlank(cfg.getProperty(VARSUB_IMPL_KEY), DEFAULT_VAR_SUB_IMPL);
     String variablePrefix = defaultIfBlank(cfg.getProperty(VARSUB_PREFIX_KEY), DEFAULT_VARIABLE_PREFIX);
     String variablePostfix = defaultIfBlank(cfg.getProperty(VARSUB_POSTFIX_KEY), DEFAULT_VARIABLE_POSTFIX);
-    Properties expandedVariables = new VariableExpander(variablePrefix, variablePostfix).resolve(variables);
+    Properties expandedVariables = buildVariableExpander(variablePrefix, variablePostfix)
+            .withLogMasking(getLogMaskedKeys(cfg))
+            .resolve(variables);
+
 
     VariableSubstitutionType impl = VariableSubstitutionType.valueOf(varSubImpl);
     return impl.create().doSubstitution(xml, expandedVariables, variablePrefix, variablePostfix);
+  }
+
+  protected VariableExpander buildVariableExpander(String variablePrefix, String variablePostfix) {
+    return new VariableExpander(variablePrefix, variablePostfix);
+  }
+
+  protected List<String> getLogMaskedKeys(Properties cfg) {
+    return LogMasking.getLogMaskingConfigKeys(cfg);
   }
 
   String process(URL urlToXml, Properties variables) throws CoreException {

--- a/src/main/java/com/adaptris/core/varsub/SimpleStringSubstitution.java
+++ b/src/main/java/com/adaptris/core/varsub/SimpleStringSubstitution.java
@@ -1,9 +1,11 @@
 package com.adaptris.core.varsub;
 
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,18 +37,24 @@ public class SimpleStringSubstitution extends VariableSubstitutable {
 
   @Override
   public String doSubstitution(String input, Properties variableSubs, String variablePrefix, String variablePostFix) throws CoreException {
-    Set<String> keySet = variableSubs.stringPropertyNames();
+    Set<String> keySet = variableSubs.stringPropertyNames().stream().filter(s -> !s.equals(Constants.VARSUB_LOG_MASKED_VARIABLES_KEY)).collect(Collectors.toSet());
+    List<String> logMaskedKeys = LogMasking.getLogMaskingConfigKeys(variableSubs);
     String substitute = input;
     log.trace("Performing configuration variable substitution");
     for (String key : keySet) {
       String variable = variablePrefix + key + variablePostFix;
+      String substitution = variableSubs.getProperty(key);
       if (verboseMode) {
-        log.trace("Replacing {} with {}", variable, variableSubs.getProperty(key));
+        doLog(variable, getLogMaskedValue(logMaskedKeys, key, substitution));
       }
-      substitute = substitute.replace(variable, variableSubs.getProperty(key));
+      substitute = substitute.replace(variable, substitution);
     }
     validateSubstitutions(substitute, variablePrefix, variablePostFix);
     return substitute;
+  }
+
+  protected void doLog(String variable, String substitution) {
+    log.trace("Replacing {} with {}", variable, substitution);
   }
 
   private void validateSubstitutions(String input, String variablePrefix, String variablePostFix) throws CoreException {

--- a/src/main/java/com/adaptris/core/varsub/SystemPropertiesPreProcessor.java
+++ b/src/main/java/com/adaptris/core/varsub/SystemPropertiesPreProcessor.java
@@ -83,8 +83,7 @@ public class SystemPropertiesPreProcessor extends VariablePreProcessorImpl {
     String varSubImpl = defaultIfBlank(cfg.getProperty(SYSPROP_IMPL_KEY), DEFAULT_VAR_SUB_IMPL);
     String variablePrefix = defaultIfBlank(cfg.getProperty(SYSPROP_PREFIX_KEY), DEFAULT_VARIABLE_PREFIX);
     String variablePostfix = defaultIfBlank(cfg.getProperty(SYSPROP_POSTFIX_KEY), DEFAULT_VARIABLE_POSTFIX);
-    VariableSubstitutionType impl = VariableSubstitutionType.valueOf(varSubImpl);
-    return impl.create().doSubstitution(xml, System.getProperties(), variablePrefix, variablePostfix);
+    return build(varSubImpl).doSubstitution(xml, System.getProperties(), variablePrefix, variablePostfix);
   }
 
 }

--- a/src/main/java/com/adaptris/core/varsub/VariableExpander.java
+++ b/src/main/java/com/adaptris/core/varsub/VariableExpander.java
@@ -1,8 +1,6 @@
 package com.adaptris.core.varsub;
 
-import java.util.LinkedHashSet;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -51,10 +49,16 @@ public class VariableExpander {
 
   private String varPrefix;
   private String varSuffix;
+  private List<String> keysToMask = Collections.emptyList();
 
   public VariableExpander(String prefix, String suffix) {
     setVarPrefix(prefix);
     setVarSuffix(suffix);
+  }
+
+  public VariableExpander withLogMasking(List<String> keysToMask) {
+    this.keysToMask = keysToMask;
+    return this;
   }
 
   public Properties resolve(Properties input) throws CoreException {
@@ -65,7 +69,7 @@ public class VariableExpander {
       Properties environment = PropertyFileLoader.getEnvironment();
       for (String key : resolved.stringPropertyNames()) {
         String value = resolved.getProperty(key);
-        log.trace("Initial key [{}], value[{}]", key, value);
+        doLog(key, getLogMaskedValue(key, value));
         // Loop through and sort out all the defined variables first.
         value = handleExpansion(key, value, resolved);
         // Now loop through and expand any system properties.
@@ -78,6 +82,14 @@ public class VariableExpander {
       throw ExceptionHelper.wrapCoreException(e);
     }
     return result;
+  }
+
+  void doLog(String key, String value) {
+    log.trace("Initial key [{}], value[{}]", key, value);
+  }
+
+  protected String getLogMaskedValue(String key, String value) {
+    return LogMasking.getLogMaskedValue(keysToMask, key, value);
   }
 
   private String handleExpansion(String key, String initialValue, Properties knownVariables) throws Exception {

--- a/src/main/java/com/adaptris/core/varsub/VariablePreProcessorImpl.java
+++ b/src/main/java/com/adaptris/core/varsub/VariablePreProcessorImpl.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Properties;
 
 import org.apache.commons.io.IOUtils;
 
@@ -46,5 +48,15 @@ public abstract class VariablePreProcessorImpl extends ConfigPreProcessorImpl {
   }
 
   protected abstract String expand(String xml) throws Exception;
+
+  protected List<String> getLogMaskedKeys(Properties cfg) {
+    return LogMasking.getLogMaskingConfigKeys(cfg);
+  }
+
+  VariableSubstitutable build(String varSubImpl) {
+    VariableSubstitutionType impl = VariableSubstitutionType.valueOf(varSubImpl);
+    List<String> logMaskedKeys = getLogMaskedKeys(getProperties());
+    return impl.create().withLogMaskedKeys(logMaskedKeys);
+  }
 
 }

--- a/src/main/java/com/adaptris/core/varsub/VariableSubstitutable.java
+++ b/src/main/java/com/adaptris/core/varsub/VariableSubstitutable.java
@@ -1,11 +1,15 @@
 package com.adaptris.core.varsub;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 import com.adaptris.core.CoreException;
 
 abstract class VariableSubstitutable {
-  
+
+  private List<String> keysToMask = Collections.emptyList();
+
   /**
    * Do the substitution.
    * 
@@ -19,5 +23,31 @@ abstract class VariableSubstitutable {
    */
   abstract String doSubstitution(String input, Properties variableSubs, String variablePrefix, String variablePostFix)
       throws CoreException;
+
+  public VariableSubstitutable withLogMaskedKeys(List<String> keysToMask) {
+    this.keysToMask = keysToMask;
+    return this;
+  }
+
+  /**
+   * Gets the value with any log masking based on the provided keysToMask
+   * @param keysToMask
+   * @param key
+   * @param value
+   * @return
+   */
+  protected String getLogMaskedValue(List<String> keysToMask, String key, String value) {
+    return LogMasking.getLogMaskedValue(keysToMask, key, value);
+  }
+
+  /**
+   * Gets the value with any log masking based on the value provided to withLogMaskedKeys()
+   * @param key
+   * @param value
+   * @return
+   */
+  protected String getLogMaskedValue(String key, String value) {
+    return LogMasking.getLogMaskedValue(keysToMask, key, value);
+  }
 
 }

--- a/src/main/java/com/adaptris/core/varsub/VariableSubstitutionPreProcessor.java
+++ b/src/main/java/com/adaptris/core/varsub/VariableSubstitutionPreProcessor.java
@@ -124,7 +124,11 @@ public class VariableSubstitutionPreProcessor extends ConfigPreProcessorImpl {
     String result = xml;
     try {
       Properties vars = loadSubstitutions();
-      result = new Processor(getProperties()).process(xml, vars);
+      Properties cfg = getProperties();
+      if (vars.containsKey(LogMasking.LOG_MASKING_CONFIG_KEY)) {
+        cfg.setProperty(LogMasking.LOG_MASKING_CONFIG_KEY,  vars.getProperty(LogMasking.LOG_MASKING_CONFIG_KEY));
+      }
+      result = buildProcessor(cfg).process(xml, vars);
     } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }
@@ -136,11 +140,19 @@ public class VariableSubstitutionPreProcessor extends ConfigPreProcessorImpl {
     String result = "";
     try {
       Properties vars = loadSubstitutions();
-      result = new Processor(getProperties()).process(urlToXml, vars);
+      Properties cfg = getProperties();
+      if (vars.containsKey(LogMasking.LOG_MASKING_CONFIG_KEY)) {
+        cfg.setProperty(LogMasking.LOG_MASKING_CONFIG_KEY,  vars.getProperty(LogMasking.LOG_MASKING_CONFIG_KEY));
+      }
+      result = buildProcessor(cfg).process(urlToXml, vars);
     } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }
     return result;
+  }
+
+  Processor buildProcessor(Properties cfg) {
+    return new Processor(cfg);
   }
 
   private Properties loadSubstitutions() throws IOException, CoreException {

--- a/src/main/java/com/adaptris/core/varsub/VariableSubstitutionService.java
+++ b/src/main/java/com/adaptris/core/varsub/VariableSubstitutionService.java
@@ -130,8 +130,12 @@ public class VariableSubstitutionService extends com.adaptris.core.ServiceImp {
     if (properties.containsKey(LogMasking.LOG_MASKING_CONFIG_KEY)) {
       cfg.setProperty(LogMasking.LOG_MASKING_CONFIG_KEY,  properties.getProperty(LogMasking.LOG_MASKING_CONFIG_KEY));
     }
-    String xml = new Processor(cfg).process(inputToProcess, properties);
+    String xml = buildProcessor(cfg).process(inputToProcess, properties);
     return xml;
+  }
+
+  Processor buildProcessor(Properties cfg) {
+    return new Processor(cfg);
   }
 
   private Properties loadSubstitutions(AdaptrisMessage msg) throws CoreException {

--- a/src/main/java/com/adaptris/core/varsub/VariableSubstitutionService.java
+++ b/src/main/java/com/adaptris/core/varsub/VariableSubstitutionService.java
@@ -125,7 +125,12 @@ public class VariableSubstitutionService extends com.adaptris.core.ServiceImp {
 
   public String process(String inputToProcess, Properties properties) throws CoreException {
     Args.notNull(inputToProcess, "input");
-    String xml = new Processor(configAsProperties()).process(inputToProcess, properties);
+    Properties cfg = configAsProperties();
+    // if log masking is set, transfer it to Processor config
+    if (properties.containsKey(LogMasking.LOG_MASKING_CONFIG_KEY)) {
+      cfg.setProperty(LogMasking.LOG_MASKING_CONFIG_KEY,  properties.getProperty(LogMasking.LOG_MASKING_CONFIG_KEY));
+    }
+    String xml = new Processor(cfg).process(inputToProcess, properties);
     return xml;
   }
 

--- a/src/main/java/com/adaptris/core/varsub/XStreamMarshaller.java
+++ b/src/main/java/com/adaptris/core/varsub/XStreamMarshaller.java
@@ -96,8 +96,17 @@ public class XStreamMarshaller extends com.adaptris.core.XStreamMarshaller {
   @Override
   public Object unmarshal(String input) throws CoreException {
     Args.notNull(input, "input");
-    String xml = new Processor(configAsProperties()).process(input, loadSubstitutions());
+    Properties subs = loadSubstitutions();
+    Properties cfg = configAsProperties();
+    if (subs.containsKey(LogMasking.LOG_MASKING_CONFIG_KEY)) {
+      cfg.setProperty(LogMasking.LOG_MASKING_CONFIG_KEY,  subs.getProperty(LogMasking.LOG_MASKING_CONFIG_KEY));
+    }
+    String xml = buildProcessor(cfg).process(input, subs);
     return getInstance().fromXML(xml);
+  }
+
+  Processor buildProcessor(Properties cfg) {
+    return new Processor(cfg);
   }
 
   @Override
@@ -166,7 +175,7 @@ public class XStreamMarshaller extends com.adaptris.core.XStreamMarshaller {
     return result;
   }
 
-  private Properties configAsProperties() {
+  Properties configAsProperties() {
     Properties config = new Properties();
     config.setProperty(VARSUB_PREFIX_KEY, variablePrefix());
     config.setProperty(VARSUB_POSTFIX_KEY, variableSuffix());

--- a/src/test/java/com/adaptris/core/varsub/SimpleStringSubstitutionTest.java
+++ b/src/test/java/com/adaptris/core/varsub/SimpleStringSubstitutionTest.java
@@ -2,7 +2,9 @@ package com.adaptris.core.varsub;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
 
+import java.util.List;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
@@ -114,6 +116,23 @@ public class SimpleStringSubstitutionTest {
     } catch (CoreException e) {
       assertTrue(e.getMessage().contains("${over} is undefined"));
     }
+  }
+
+  @Test
+  public void testSubstitutionWithMaskedLogging() throws Exception {
+    Properties props = new Properties();
+    props.put("fox", "fox");
+    SimpleStringSubstitution s = spy((SimpleStringSubstitution)VariableSubstitutionType.SIMPLE_WITH_LOGGING.create());
+
+    props.put(Constants.VARSUB_LOG_MASKED_VARIABLES_KEY, "fox");
+    s.doSubstitution(testInput, props, "${", "}");
+    verify(s).doSubstitution(testInput, props, "${", "}");
+    verify(s).getLogMaskedValue(List.of("fox"), "fox", "fox");
+    verify(s).doLog("${fox}", LogMasking.DEFAULT_LOG_MASK);
+
+    assertEquals("fox", s.getLogMaskedValue("fox", "fox"));
+    s.withLogMaskedKeys(List.of("fox"));
+    assertEquals(LogMasking.DEFAULT_LOG_MASK, s.getLogMaskedValue("fox", "fox"));
   }
 
 }

--- a/src/test/java/com/adaptris/core/varsub/VariableSubstitutionPreProcessorTest.java
+++ b/src/test/java/com/adaptris/core/varsub/VariableSubstitutionPreProcessorTest.java
@@ -4,13 +4,14 @@ import static com.adaptris.core.varsub.PropertyFileLoaderTest.SAMPLE_MISSING_SUB
 import static com.adaptris.core.varsub.PropertyFileLoaderTest.SAMPLE_SUBSTITUTION_PROPERTIES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 
 import com.adaptris.core.Adapter;
@@ -73,6 +75,32 @@ public class VariableSubstitutionPreProcessorTest extends BaseCase {
     Adapter adapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(xml);
 
     doStandardAssertions(adapter);
+  }
+
+  @Test
+  public void testSimpleVarSubAdapterRegistryWithLogMasking() throws Exception {
+    // We don't actually want to go to the file system for the variable substitutions
+    Properties variableSubstitutions = createProperties();
+    variableSubstitutions.setProperty(LogMasking.LOG_MASKING_CONFIG_KEY, "adapter.id,channel.id,channel.alternate.id,workflow.id1,workflow.id2");
+    when(propertyFileLoader.load(anyString(), anyBoolean())).thenReturn(variableSubstitutions);
+
+    preProcessor = spy(preProcessor);
+
+    AtomicReference<Processor> processor = new AtomicReference<>();
+    AtomicReference<VariableExpander> expander = new AtomicReference<>();
+    when(preProcessor.buildProcessor(any(Properties.class))).thenAnswer((props) -> {
+      processor.set(spy(new Processor(props.getArgument(0))));
+      when(processor.get().buildVariableExpander(any(), any())).thenAnswer((args) -> {
+        expander.set(spy(new VariableExpander("{", "}")));
+        return expander.get();
+      });
+      return processor.get();
+    });
+
+    String xml = preProcessor.process(variablesAdapterFile.toURI().toURL());
+    Adapter adapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(xml);
+    doStandardAssertions(adapter);
+    verify(expander.get(), times(5)).doLog(anyString(), eq(LogMasking.DEFAULT_LOG_MASK));
   }
 
   @Test

--- a/src/test/java/com/adaptris/core/varsub/VariableSubstitutionServiceTest.java
+++ b/src/test/java/com/adaptris/core/varsub/VariableSubstitutionServiceTest.java
@@ -1,9 +1,16 @@
 package com.adaptris.core.varsub;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -35,6 +42,36 @@ public class VariableSubstitutionServiceTest {
     LifecycleHelper.close(service);
 
     assertEquals("some text with some variable key to replace", msg.getContent());
+  }
+
+  @Test
+  public void testDoServiceWithLogMasking() throws IOException, CoreException, ParserConfigurationException, SAXException, URISyntaxException {
+    VariableSubstitutionService service = new VariableSubstitutionService();
+    service.setInput(new StringPayloadDataInputParameter());
+    service.setOutput(new StringPayloadDataOutputParameter());
+    service.setVariables(new ConstantDataInputParameter(String.format("var=variable\n%s=%s", LogMasking.LOG_MASKING_CONFIG_KEY, "var")));
+
+    String input = "some text with some ${var} key to replace";
+    AdaptrisMessage msg = DefaultMessageFactory.getDefaultInstance().newMessage(input);
+
+    service = spy(service);
+
+    AtomicReference<Processor> processor = new AtomicReference<>();
+    AtomicReference<VariableExpander> expander = new AtomicReference<>();
+    when(service.buildProcessor(any(Properties.class))).thenAnswer((props) -> {
+      processor.set(spy(new Processor(props.getArgument(0))));
+      when(processor.get().buildVariableExpander(any(), any())).thenAnswer((args) -> {
+        expander.set(spy(new VariableExpander("{", "}")));
+        return expander.get();
+      });
+      return processor.get();
+    });
+
+    LifecycleHelper.initAndStart(service);
+    service.doService(msg);
+    LifecycleHelper.close(service);
+
+    verify(expander.get(), times(1)).doLog(anyString(), eq(LogMasking.DEFAULT_LOG_MASK));
   }
 
   @Test

--- a/src/test/java/com/adaptris/core/varsub/XStreamMarshallerTest.java
+++ b/src/test/java/com/adaptris/core/varsub/XStreamMarshallerTest.java
@@ -2,6 +2,7 @@ package com.adaptris.core.varsub;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.*;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -10,6 +11,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.nio.charset.Charset;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +28,7 @@ public class XStreamMarshallerTest extends BaseCase {
 
   private static final String PROPS_VARIABLES_ADAPTER = "varsub.variables.adapter.xml";
   private static final String SAMPLE_SUBSTITUTION_PROPERTIES = "varsub.variables.properties";
+  private static final String SAMPLE_MASKED_SUBSTITUTION_PROPERTIES = "varsub.variables.masked.properties";
 
   private File variablesAdapterFile;
 
@@ -170,6 +174,26 @@ public class XStreamMarshallerTest extends BaseCase {
     marshaller.setSubstitutionType(VariableSubstitutionType.SIMPLE_WITH_LOGGING);
     Adapter adapter = (Adapter) marshaller.unmarshal(IOUtils.toString(variablesAdapterFile.toURI().toURL(), Charset.defaultCharset()));
     doStandardAssertions(adapter);
+  }
+
+  @Test
+  public void testUnmarshal_WithMaskedLogging() throws Exception {
+    XStreamMarshaller marshaller = spy(createMarshaller());
+    marshaller.addVariablePropertiesUrls(PROPERTIES.getProperty(SAMPLE_MASKED_SUBSTITUTION_PROPERTIES));
+    marshaller.setSubstitutionType(VariableSubstitutionType.SIMPLE_WITH_LOGGING);
+    AtomicReference<Processor> processor = new AtomicReference<>();
+    AtomicReference<VariableExpander> expander = new AtomicReference<>();
+    when(marshaller.buildProcessor(any(Properties.class))).thenAnswer((props) -> {
+      processor.set(spy(new Processor(props.getArgument(0))));
+      when(processor.get().buildVariableExpander(any(), any())).thenAnswer((args) -> {
+        expander.set(spy(new VariableExpander("{", "}")));
+        return expander.get();
+      });
+      return processor.get();
+    });
+    Adapter adapter = (Adapter) marshaller.unmarshal(IOUtils.toString(variablesAdapterFile.toURI().toURL(), Charset.defaultCharset()));
+    doStandardAssertions(adapter);
+    verify(expander.get(), times(5)).doLog(anyString(), eq(LogMasking.DEFAULT_LOG_MASK));
   }
 
   @Test

--- a/src/test/resources/unit-tests.properties.template
+++ b/src/test/resources/unit-tests.properties.template
@@ -1,5 +1,6 @@
 varsub.variables.adapter.xml=@TEST_DATA_DIR@/variables-adapter.xml
 varsub.variables.properties=file:///@TEST_DATA_DIR@/sample-variable-substitutions.properties
+varsub.variables.masked.properties=file:///@TEST_DATA_DIR@/sample-variable-substitutions-masked.properties
 varsub.sysprop.adapter.xml=@TEST_DATA_DIR@/sysprops-adapter.xml
 varsub.environment.adapter.xml=@TEST_DATA_DIR@/environment-adapter.xml
 varsub.missing.variables.properties=file:///@TEST_DATA_DIR@/sample-missing-variable-substitutions.properties

--- a/src/test/resources/var-sub/sample-variable-substitutions-masked.properties
+++ b/src/test/resources/var-sub/sample-variable-substitutions-masked.properties
@@ -1,0 +1,1 @@
+variable-substitution.properties.maskedVariables=adapter.id,channel.id,channel.alternate.id,workflow.id1,workflow.id2


### PR DESCRIPTION
## Motivation

https://adaptris.atlassian.net/browse/INTERLOK-4556

## Modification

- Added LogMasking.class which encapsulates common logic
- Updated the various substitution classes to support a specific key (variable-substitution.properties.maskedVariables) that when passed into the variable substitutions, will mask any logging of values for the variables defined in the comma separated list

## PR Checklist

- [x] been self-reviewed.
- [ x] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ x] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Users can pass in a comma separated value into the variable substitutions:

variable-substitution.properties.maskedVariables=key1,key2,ley3

Which will mask the logging (at TRACE level) with ***

## Testing

Check the test cases, or setup an adapter with variable substitutions and logging set to TRACE and add the maskedVariables config as above.
